### PR TITLE
Fix validation for `included` clause in compound documents

### DIFF
--- a/pydantic_jsonapi/response.py
+++ b/pydantic_jsonapi/response.py
@@ -26,7 +26,7 @@ class ResponseModel(GenericModel, Generic[DataT]):
     """
     """
     data: DataT
-    included: Optional[dict]
+    included: Optional[list]
     meta: Optional[dict]
     links: Optional[LinksType]
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -10,7 +10,8 @@ class TestJsonApiResponse:
     def test_attributes_as_dict(self):
         MyResponse = JsonApiResponse('item', dict)
         obj_to_validate = {
-            'data': {'id': '123', 'type': 'item', 'attributes': {}}
+            'data': {'id': '123', 'type': 'item', 'attributes': {}},
+            'included': [{'id': '456', 'type': 'not-an-item', 'attributes': {}}]
         }
         my_request_obj = MyResponse(**obj_to_validate)
         assert my_request_obj.dict() == {
@@ -19,6 +20,11 @@ class TestJsonApiResponse:
                 'type': 'item',
                 'attributes': {},
             },
+            'included': [{
+                'id': '456',
+                'type': 'not-an-item',
+                'attributes': {}
+            }]
         }
 
     def test_attributes_as_item_model(self):


### PR DESCRIPTION
This PR adds a fix for compound documents validation. According to [JSONAPI](https://jsonapi.org/format/#document-compound-documents) specs `included` clause should have a `list` type, not `dict`. 