### PR TITLE
Fix parsing for to-many relationships

### DIFF
--- a/pydantic_jsonapi/relationships.py
+++ b/pydantic_jsonapi/relationships.py
@@ -1,5 +1,5 @@
 
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Union
 
 from pydantic import BaseModel
 from pydantic_jsonapi.links import LinksType
@@ -7,7 +7,7 @@ from pydantic_jsonapi.links import LinksType
 
 class RelationshipModel(BaseModel):
     links: Optional[LinksType]
-    data: Optional[dict]
+    data: Optional[Union[list, dict]]
     meta: Optional[dict]
 
 RelationshipsType = Mapping[str, RelationshipModel]

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -12,13 +12,33 @@ class TestRelationshipsType:
     def test_follows_strucutre(self):
         validated = Relatable(relationships={
             'walter': {
+                'data': None,
                 'links': {
                     'self': '/person/walter'
                 }
             },
             'wendy': {
+                'data': {
+                    'id': '1',
+                    'type': 'wendy-type'
+                },
                 'links': {
                     'self': '/person/wendy'
+                }
+            },
+            'wandas': {
+                'data': [],
+                'links': {
+                    'self': '/person/wandas'
+                }
+            },
+            'warners': {
+                'data': [{
+                    'id': '1',
+                    'type': 'warner-type'
+                }],
+                'links': {
+                    'self': '/person/warners'
                 }
             }
         })
@@ -35,9 +55,29 @@ class TestRelationshipsType:
                     'links': {
                         'self': '/person/wendy'
                     },
-                    'data': None,
+                    'data': {
+                        'id': '1',
+                        'type': 'wendy-type'
+                    },
                     'meta': None,
-                }
+                },
+                'wandas': {
+                    'links': {
+                        'self': '/person/wandas'
+                    },
+                    'data': [],
+                    'meta': None,
+                },
+                'warners': {
+                    'links': {
+                        'self': '/person/warners'
+                    },
+                    'data': [{
+                        'id': '1',
+                        'type': 'warner-type'
+                    }],
+                    'meta': None,
+                },
             }
         }
 


### PR DESCRIPTION
Fix type annotation for `relationships.data` to support to-many relationships in according with [specs](https://jsonapi.org/format/#document-resource-object-linkage). Also add all possible resource linkage representations to the tests.