### PR TITLE
Add support for resources without attributes

### DIFF
--- a/pydantic_jsonapi/response.py
+++ b/pydantic_jsonapi/response.py
@@ -1,10 +1,8 @@
 from typing import Generic, TypeVar, Optional, List, Any, Type
 from typing_extensions import Literal
 
-from pydantic import validator
 from pydantic.generics import GenericModel
 
-from pydantic_jsonapi.errors import Error
 from pydantic_jsonapi.filter import filter_none
 from pydantic_jsonapi.relationships import RelationshipsType
 from pydantic_jsonapi.resource_links import ResourceLinks
@@ -17,8 +15,11 @@ class ResponseDataModel(GenericModel, Generic[TypeT, AttributesT]):
     """
     id: str
     type: TypeT
-    attributes: AttributesT
+    attributes: AttributesT = {}
     relationships: Optional[RelationshipsType]
+
+    class Config:
+        validate_all = True
 
 
 DataT = TypeVar('DataT')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -13,8 +13,8 @@ class TestJsonApiResponse:
             'data': {'id': '123', 'type': 'item', 'attributes': {}},
             'included': [{'id': '456', 'type': 'not-an-item', 'attributes': {}}]
         }
-        my_request_obj = MyResponse(**obj_to_validate)
-        assert my_request_obj.dict() == {
+        my_response_object = MyResponse(**obj_to_validate)
+        assert my_response_object.dict() == {
             'data': {
                 'id': '123',
                 'type': 'item',
@@ -26,6 +26,38 @@ class TestJsonApiResponse:
                 'attributes': {}
             }]
         }
+
+    def test_missing_attributes_dict(self):
+        MyResponse = JsonApiResponse('item', dict)
+        obj_to_validate = {
+            'data': {'id': '123', 'type': 'item'}
+        }
+        my_response_object = MyResponse(**obj_to_validate)
+        assert my_response_object.dict() == {
+            'data': {
+                'id': '123',
+                'type': 'item',
+                'attributes': {},
+            }
+        }
+
+    def test_missing_attributes_empty_model(self):
+        class EmptyModel(BaseModel):
+            pass
+
+        MyResponse = JsonApiResponse('item', EmptyModel)
+        obj_to_validate = {
+            'data': {'id': '123', 'type': 'item'}
+        }
+        my_response_object = MyResponse(**obj_to_validate)
+        assert my_response_object.dict() == {
+            'data': {
+                'id': '123',
+                'type': 'item',
+                'attributes': {},
+            }
+        }
+        assert isinstance(my_response_object.data.attributes, EmptyModel)
 
     def test_attributes_as_item_model(self):
         ItemResponse = JsonApiResponse('item', ItemModel)
@@ -47,8 +79,8 @@ class TestJsonApiResponse:
                 },
             }
         }
-        my_request_obj = ItemResponse(**obj_to_validate)
-        assert my_request_obj.dict() == {
+        my_response_obj = ItemResponse(**obj_to_validate)
+        assert my_response_obj.dict() == {
             'data': {
                 'id': '123',
                 'type': 'item',
@@ -91,8 +123,8 @@ class TestJsonApiResponse:
                 },
             ],
         }
-        my_request_obj = ItemResponse(**obj_to_validate)
-        assert my_request_obj.dict() == {
+        my_response_obj = ItemResponse(**obj_to_validate)
+        assert my_response_obj.dict() == {
             'data': [
                 {
                     'id': '123',


### PR DESCRIPTION
Fix parsing for [resource objects](https://jsonapi.org/format/#document-resource-objects) without `attributes` clause which is optional and may be omitted by server if resource doesn't contain any attributes.

**Some implementation notes:**
Current implementation causes a little overhead (since it'll set `validate_always=True` for all fields, not `attributes` only) but it's based on a documented feature. I've found a way to trigger all class validators for a certain field only by adding a dummy validator with `always=True` but that behaviour is not documented.

Therefore I suppose we should use the implementation proposed in this PR to fix the bug ASAP. Later I'm going to clarify the situation with the faster implementation and add it in a separate PR if it'll turn out to be valid.