### PR TITLE
function to transform pydantic ValidationError to json:api errors

### DIFF
--- a/pydantic_jsonapi/__init__.py
+++ b/pydantic_jsonapi/__init__.py
@@ -1,11 +1,12 @@
 from .request import JsonApiRequest
 from .response import JsonApiResponse
 from .factory import JsonApiModel
-from .errors import ErrorResponse
+from .errors import ErrorResponse, transform_to_json_api_errors
 
 __all__ = [
     'JsonApiModel',
     'JsonApiRequest',
     'JsonApiResponse',
-    'ErrorResponse'
+    'ErrorResponse',
+    'transform_to_json_api_errors',
 ]

--- a/pydantic_jsonapi/filter.py
+++ b/pydantic_jsonapi/filter.py
@@ -1,10 +1,17 @@
-from typing import Any
+from typing import TypeVar
 from collections.abc import Mapping, Iterable
 
-def filter_none(d: Any):
-    if isinstance(d, dict):
-        return {k: filter_none(v) for k, v in d.items() if v is not None}
-    elif isinstance(d, list):
-        return [filter_none(item) for item in d]
-    return d
-
+T = TypeVar('T')
+def filter_none(thing_to_traverse: T) -> T:
+    if isinstance(thing_to_traverse, dict):
+        return {
+            k: filter_none(v)
+            for k, v in thing_to_traverse.items()
+            if v is not None
+        }
+    elif isinstance(thing_to_traverse, list):
+        return [
+            filter_none(item)
+            for item in thing_to_traverse
+        ]
+    return thing_to_traverse

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,10 @@
 from pydantic import BaseModel
-
+from pydantic_jsonapi import JsonApiRequest
 
 class ItemModel(BaseModel):
     name: str
     quantity: int
     price: float
+
+item_type_name = 'item'
+ItemRequest = JsonApiRequest(item_type_name, ItemModel)


### PR DESCRIPTION
adds a new top-level function: `transform_to_json_api_errors(e: ValidationError) -> dict: ...`

example usage with FastApi:
```python
from fastapi import FastApi
from starlette.requests import Request
from starlette.responses import JSONResponse
from pydantic import ValidationError
from pydantic_jsonapi import transform_to_json_api_errors

app = FastAPI()


@app.exception_handler(ValidationError)
async def validation_error_handler(request: Request, exc: ValidationError):
    return JSONResponse(
        status_code=400,
        content=transform_to_json_api_errors(exc),
    )
```