### PR TITLE
allow optional relationships on requests

### DIFF
--- a/pydantic_jsonapi/relationships.py
+++ b/pydantic_jsonapi/relationships.py
@@ -6,10 +6,17 @@ from pydantic_jsonapi.resource_linkage import ResourceLinkage
 from pydantic_jsonapi.resource_links import ResourceLinks
 
 
-class RelationshipModel(BaseModel):
+class RequestRelationshipModel(BaseModel):
+    data: ResourceLinkage
+
+RequestRelationshipsType = Mapping[str, RequestRelationshipModel]
+RequestRelationshipsType.__doc__ = "https://jsonapi.org/format/#crud-creating"
+
+
+class ResponseRelationshipModel(BaseModel):
     links: Optional[ResourceLinks]
     data: ResourceLinkage
     meta: Optional[dict]
 
-RelationshipsType = Mapping[str, RelationshipModel]
-RelationshipsType.__doc__ = "https://jsonapi.org/format/#document-resource-object-relationships"
+ResponseRelationshipsType = Mapping[str, ResponseRelationshipModel]
+ResponseRelationshipsType.__doc__ = "https://jsonapi.org/format/#document-resource-object-relationships"

--- a/pydantic_jsonapi/request.py
+++ b/pydantic_jsonapi/request.py
@@ -1,7 +1,10 @@
 from typing import Generic, TypeVar, Optional, Any, Type
 from typing_extensions import Literal
 
+from pydantic import UUID4
 from pydantic.generics import GenericModel
+
+from pydantic_jsonapi.relationships import RequestRelationshipsType
 
 
 TypeT = TypeVar('TypeT')
@@ -11,6 +14,7 @@ class RequestDataModel(GenericModel, Generic[TypeT, AttributesT]):
     """
     type: TypeT
     attributes: AttributesT
+    relationships: Optional[RequestRelationshipsType]
 
 
 DataT = TypeVar('DataT', bound=RequestDataModel)

--- a/pydantic_jsonapi/response.py
+++ b/pydantic_jsonapi/response.py
@@ -4,7 +4,7 @@ from typing_extensions import Literal
 from pydantic.generics import GenericModel
 
 from pydantic_jsonapi.filter import filter_none
-from pydantic_jsonapi.relationships import RelationshipsType
+from pydantic_jsonapi.relationships import ResponseRelationshipsType
 from pydantic_jsonapi.resource_links import ResourceLinks
 
 
@@ -16,7 +16,7 @@ class ResponseDataModel(GenericModel, Generic[TypeT, AttributesT]):
     id: str
     type: TypeT
     attributes: AttributesT = {}
-    relationships: Optional[RelationshipsType]
+    relationships: Optional[ResponseRelationshipsType]
 
     class Config:
         validate_all = True

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,14 +1,14 @@
 from pytest import raises
 
-from pydantic_jsonapi.relationships import RelationshipsType
+from pydantic_jsonapi.relationships import ResponseRelationshipsType
 from pydantic import BaseModel, ValidationError
 
 
 class Relatable(BaseModel):
-    relationships: RelationshipsType
+    relationships: ResponseRelationshipsType
 
 
-class TestRelationshipsType:
+class TestResponseRelationshipsType:
     def test_follows_strucutre(self):
         validated = Relatable(relationships={
             'walter': {

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,7 +13,13 @@ class TestJsonApiRequest:
             'data': {'type': 'item', 'attributes': {}}
         }
         my_request_obj = DictRequest(**obj_to_validate)
-        assert my_request_obj.dict() == obj_to_validate
+        assert my_request_obj.dict() == {
+            'data': {
+                'type': 'item',
+                'attributes': {},
+                'relationships': None,
+            }
+        }
 
     def test_attributes_as_item_model(self):
         ItemRequest = JsonApiRequest('item', ItemModel)
@@ -24,7 +30,8 @@ class TestJsonApiRequest:
                     'name': 'apple',
                     'quantity': 10,
                     'price': 1.20
-                }
+                },
+                'relationships': None,
             }
         }
         my_request_obj = ItemRequest(**obj_to_validate)
@@ -87,3 +94,23 @@ class TestJsonApiRequest:
         assert e.value.errors() == [
             {'loc': ('data',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'},
         ]
+
+    def test_request_with_relationships(self):
+        MyRequest = JsonApiRequest('item', dict)
+        obj_to_validate = {
+            'data': {
+                'type': 'item',
+                'attributes': {},
+                'relationships': {
+                    'sold_at': {
+                        'data': {
+                            'type': 'store',
+                            'id': 'abc123',
+                            'meta': None
+                        },
+                    }
+                }
+            },
+        }
+        my_request_obj = MyRequest(**obj_to_validate)
+        assert my_request_obj.dict() == obj_to_validate


### PR DESCRIPTION
refs: #14 
of note here, the JSON api somewhat differentiates between request relationships and response relationships. On request, it only specifies that if a relationships object is provided by the request that it must have a `data` member: https://jsonapi.org/format/#crud-creating

This makes some sense, more sensibly for a client to provide the types and ids of objects they want the created resource to be related to, rather than the href information for those relationships