### PR TITLE
Allow attributes to be left out of request

### DIFF
--- a/pydantic_jsonapi/request.py
+++ b/pydantic_jsonapi/request.py
@@ -13,7 +13,7 @@ class RequestDataModel(GenericModel, Generic[TypeT, AttributesT]):
     """
     """
     type: TypeT
-    attributes: AttributesT
+    attributes: Optional[AttributesT]
     id: Optional[str]
     relationships: Optional[RequestRelationshipsType]
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -64,12 +64,5 @@ def test_transform_to_json_api_errors():
                 },
                 'title': 'value_error.const'
             },
-            {
-                'detail': 'field required',
-                'source': {
-                    'pointer': '/data/attributes'
-                },
-                'title': 'value_error.missing'
-            },
         ]
     }

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -39,6 +39,19 @@ class TestJsonApiRequest:
         my_request_obj = ItemRequest(**obj_to_validate)
         assert my_request_obj.dict() == obj_to_validate
 
+    def test_attributes_not_required(self):
+        MyRequest = JsonApiRequest('item', dict)
+        obj_to_validate = {
+            'data': {
+                'type': 'item',
+                'attributes': None,
+                'relationships': None,
+                'id': None,
+            }
+        }
+        my_request_obj = MyRequest(**obj_to_validate)
+        assert my_request_obj.dict() == obj_to_validate
+
     def test_attributes_as_item_model__empty_dict(self):
         ItemRequest = JsonApiRequest('item', ItemModel)
         obj_to_validate = {
@@ -71,18 +84,6 @@ class TestJsonApiRequest:
                 'type': 'value_error.const',
                 'ctx': {'given': 'not_an_item', 'permitted': ('item',)},
             },
-        ]
-
-    def test_attributes_required(self):
-        MyRequest = JsonApiRequest('item', dict)
-        obj_to_validate = {
-            'data': {'type': 'item', 'attributes': None}
-        }
-        with raises(ValidationError) as e:
-            MyRequest(**obj_to_validate)
-
-        assert e.value.errors() == [
-            {'loc': ('data', 'attributes'), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
         ]
 
     def test_data_required(self):


### PR DESCRIPTION
Allowed by the spec:
https://jsonapi.org/format/#document-resource-objects
See also:
https://jsonapi.org/format/#crud-updating-resource-relationships
This can also apply to POST/create as we may have an object with
relationships only

-- 

I'm not a 100% sure if this was intentional in the original design of `pydantic-jsonapi` because of the test case for it, but thought I'd make the PR given its allowed in the spec